### PR TITLE
add the --compressed flag to curl to handle gzipped data

### DIFF
--- a/downloader.sh
+++ b/downloader.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-n=`curl -s https://darknetdiaries.com/ | grep "https://darknetdiaries.com/episode/[0-9]\+/" | cut -d '/' -f5`
+n=`curl --compressed -s https://darknetdiaries.com/ | grep "https://darknetdiaries.com/episode/[0-9]\+/" | cut -d '/' -f5`
 echo "[*] There are $n episodes available"
 for i in $(seq 1 $n); do
-	response=`curl -s "https://darknetdiaries.com/episode/$i/" | grep '"mp3"\|"title"' | cut -d '"' -f4 | tr '\n' ';'`
+	response=`curl --compressed -s "https://darknetdiaries.com/episode/$i/" | grep '"mp3"\|"title"' | cut -d '"' -f4 | tr '\n' ';'`
 	url=`echo "$response" | cut -d ';' -f1`
 	ep_name=`echo "$response" | cut -d ';' -f2`
 	echo "[+] Downloading episode \"$ep_name\" from \"$url\""


### PR DESCRIPTION
The `downloader.sh` script is currently broken because `darknetdiaries.com` returns gzip-encoded data, and `curl` does not decompress it automatically.

![img](https://i.imgur.com/kgttin8.png)

This adds the `--compressed` flag to curl, to make it handle the response correctly.